### PR TITLE
Bugfix scroll cutoff

### DIFF
--- a/swdapp/src/lib/components/quoteCards.svelte
+++ b/swdapp/src/lib/components/quoteCards.svelte
@@ -16,7 +16,7 @@
     
     let scrollBarStyle = `
         flex flex-col gap-3
-        max-h-96 overflow-y-auto
+        cards-max-h overflow-y-auto
         [&::-webkit-scrollbar]:w-2
         [&::-webkit-scrollbar-track]:rounded-full
         [&::-webkit-scrollbar-track]:bg-gray-100
@@ -56,6 +56,13 @@
     }
 
 </script>
+
+<style>
+    .cards-max-h {
+        /* max-height: calc(100vh - 25%); */
+        max-height: calc(100vh - 19rem);
+    }
+</style>
 
 <!-- <div class="columns-1"> -->
     <!-- scrollbar -->

--- a/swdapp/src/lib/components/quoteCards.svelte
+++ b/swdapp/src/lib/components/quoteCards.svelte
@@ -60,7 +60,7 @@
 <style>
     .cards-max-h {
         /* max-height: calc(100vh - 25%); */
-        max-height: calc(100vh - 19rem);
+        max-height: calc(100vh - 18.7rem);
     }
 </style>
 

--- a/swdapp/src/lib/components/quoteCards.svelte
+++ b/swdapp/src/lib/components/quoteCards.svelte
@@ -13,15 +13,15 @@
     let quoteDetailsStyle = `
         mt-3 inline-flex items-center gap-x-1 text-sm font-semibold rounded-lg border border-transparent text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:pointer-events-none
     `;
-
+    
     let scrollBarStyle = `
-        max-h-[28.4rem] overflow-y-auto
+        flex flex-col gap-3
+        max-h-96 overflow-y-auto
         [&::-webkit-scrollbar]:w-2
         [&::-webkit-scrollbar-track]:rounded-full
         [&::-webkit-scrollbar-track]:bg-gray-100
         [&::-webkit-scrollbar-thumb]:rounded-full
         [&::-webkit-scrollbar-thumb]:bg-gray-300
-        flex flex-col gap-3
     `;
 
     if(darkMode) {
@@ -57,9 +57,9 @@
 
 </script>
 
-<div class="columns-1">
+<!-- <div class="columns-1"> -->
     <!-- scrollbar -->
-    <div class={scrollBarStyle}>
+    <div class={scrollBarStyle} id="quoteCardContainer">
         {#each quoteCards as quote }
             <div class={cardBackgroundStyle}>
                 <h3 class={cardTitleStyle}>
@@ -78,4 +78,4 @@
             </div>
         {/each}
      </div>
-</div>
+<!-- </div> -->

--- a/swdapp/src/routes/quotes/+page.svelte
+++ b/swdapp/src/routes/quotes/+page.svelte
@@ -38,7 +38,7 @@
         {_id: "da95101afa3ecfda46d1", quoteDate: "2/21/2024", quoteTime: "1:59pm", loc: "houston", deliveryDate: "2/24/2024", gallons: 5, price: 2.86, tax: 3.14},
         {_id: "09075d1659108ae43ea4", quoteDate: "2/20/2024", quoteTime: "11:35am", loc: "houston", deliveryDate: "2/23/2024", gallons: 3, price: 3.86, tax: 1.59},
         {_id: "1042af652e115fc669f3", quoteDate: "2/18/2024", quoteTime: "4:30pm", loc: "houston", deliveryDate: "2/21/2024", gallons: 10, price: 5.86, tax: 2.65},
-        {_id: "c69380778bd5ed7be644", quoteDate: "2/17/2024", quoteTime: "9:30am", loc: "houston", deliveryDate: "2/18/2024", gallons: 9, price: 4.86, tax: 3.58},
+        {_id: "c69380778bd5ed7be644", quoteDate: "2/17/2024", quoteTime: "9:30am", loc: "houston", deliveryDate: "2/18/2024", gallons: 9, price: 4.86, tax: 3.58}
     ];
 
     let dummyQuotes: QuoteCard[] = dummyQuoteData.map((dat) => {

--- a/swdapp/src/routes/quotes/+page.svelte
+++ b/swdapp/src/routes/quotes/+page.svelte
@@ -78,7 +78,7 @@
         <Header />
     </nav>
 
-    <main class="overflow-hidden max-w-full overflow-x-hidden flex flex-wrap mt-14 h-full">
+    <main class="overflow-hidden max-w-full overflow-x-hidden flex flex-wrap h-full">
         <!-- left sidebar -->
         <aside class="w-1/6 bg-[#282828] h-full flex justify-left pl-10 pt-6 text-lg">
             <nav class="flex flex-col gap-2">


### PR DESCRIPTION
- made custom css class for max height of div containing cards to be (100vh - 18.7rem) in `quoteCards.svelte`
- same height is maintained when zooming out and zooming in
- same height is also maintained when adding or reducing the number of quote cards

![image](https://github.com/ujwal2003/Software-Design-Project/assets/120876026/df90c134-232b-4a31-b44c-e991c18d58e6)
